### PR TITLE
Fix relative search bug

### DIFF
--- a/bonfire/graylog_api.py
+++ b/bonfire/graylog_api.py
@@ -53,7 +53,7 @@ class SearchRange(object):
 
     def range_in_seconds(self):
         if self.is_relative():
-            range = (arrow.now('local') - self.from_time).seconds
+            range = arrow.now('local').timestamp - self.from_time.timestamp
         else:
             range = (self.to_time - self.from_time).seconds
 


### PR DESCRIPTION
I use `graylog_api.py` as a Python wrapper of Graylog, but when I do a relative search I've got some problems with certain values :

- "10 seconds ago", "30 minutes ago", "1 hour ago", "10 hours ago", "23 hours ago" for example are OK (the `range` variable contains the good seconds)
- but "24 hours ago", "2 days ago", "4 months ago" are not correct (`range` contains sometimes 3600 seconds, sometimes 1 second).

By subtracting the timestamps, the problem is solved.
