### PR TITLE
Bump dependency upper bounds for arrow and keyring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click>=3.3,<7
-keyring>=9,<10
+keyring>=9,<11
 parsedatetime>=1.4,<3
 python-dateutil>=2.4.1,<3
 requests>=2.4.3,<3.0
-arrow>=0.5.4,<0.8
+arrow>=0.5.4,<0.12
 termcolor==1.1.0
 six>=1.9.0


### PR DESCRIPTION
I'm currently packaging bonfire for NixOS and this loosens up the package dependencies to build NixOS/nixpkgs#29813