### PR TITLE
Feat: JSON output

### DIFF
--- a/bonfire/cli.py
+++ b/bonfire/cli.py
@@ -21,7 +21,7 @@ from .config import get_config, get_password_from_keyring, store_password_in_key
 from .graylog_api import SearchRange, SearchQuery
 from .utils import cli_error, api_from_config, api_from_host
 from .output import run_logprint
-from .formats import tail_format, dump_format
+from .formats import tail_format, dump_format, json_format
 
 
 @click.command()
@@ -37,6 +37,7 @@ from .formats import tail_format, dump_format
 @click.option("-#", "--search-to", default=None, help="Query range to (default: now)")
 @click.option('-t', '--tail', 'mode', flag_value='tail', default=True, help="Show the last n lines for the query (default)")
 @click.option('-d', '--dump', 'mode', flag_value='dump', help="Print the query result as a csv")
+@click.option('-j', '--json', 'mode', flag_value='json', help="Print the raw JSON log objects, one per line")
 @click.option("-f", "--follow", default=False, is_flag=True, help="Poll the logging server for new logs matching the query (sets search from to now, limit to None)")
 @click.option("-l", "--interval", default=1000, help="Polling interval in ms (default: 1000)")
 @click.option("-n", "--limit", default=10, help="Limit the number of results (default: 10)")
@@ -200,6 +201,8 @@ def run(host,
         formatter = tail_format(fields, color)
     elif mode == "dump":
         formatter = dump_format(fields, color)
+    elif mode == "json":
+        formatter = json_format
 
     run_logprint(gl_api, q, formatter, follow, interval, latency)
 

--- a/bonfire/formats.py
+++ b/bonfire/formats.py
@@ -6,6 +6,7 @@ Created on 11.03.15
 
 from termcolor import colored
 import syslog
+import json
 
 def get_log_color_and_background(level):
     log_color = 'green'
@@ -43,3 +44,6 @@ def formatter(fields, seperator, colorful):
             return colored(msg, log_color, log_background)
         return msg
     return format
+
+def json_format(entry):
+    return json.dumps(entry.message_dict)


### PR DESCRIPTION
Bonfire should be able to output the raw JSON objects obtained from Graylog, as they often contain important data in custom fields, and JSON is the common format that can be queried with [jq](https://stedolan.github.io/jq/), pretty-printed with [jl](https://github.com/mightyguava/jl), and so on.